### PR TITLE
fix(frontend): arruma o flip do card de professores na listagem 

### DIFF
--- a/vue-app/src/components/Navegacao/FiltroProfessoresPorMateriaComponent.vue
+++ b/vue-app/src/components/Navegacao/FiltroProfessoresPorMateriaComponent.vue
@@ -210,7 +210,7 @@ export default {
     width: 1.5rem;
     height: 1.5rem;
     border: solid 1px #707070;
-    background-color: #008E4A;
+    background-color: #0a745b;
     border-radius: 2rem;
  }
 
@@ -227,7 +227,7 @@ export default {
     padding: 15px 0 15px 0;
     border:none;
     border-radius: 10px;
-    background: #008E4A;
+    background: #0a745b;
     color: white;
     font-family: 'Inter', sans-serif;
     letter-spacing: 1px;

--- a/vue-app/src/components/Professores/CardListagemProfessoresComponent.vue
+++ b/vue-app/src/components/Professores/CardListagemProfessoresComponent.vue
@@ -5,9 +5,14 @@
         
         <PopUp v-if="popupTrigger.buttonTrigger" :TogglePopup = "() => TogglePopup('buttonTrigger')" :professor="professor"/>
         
-        <div class="card-professor">
-            <div class="front" @click="goToProfessorDetail(professor.cod_professor)">
-                <div class="card-front">
+        <div class="card-professor" :class="{flipped: isFlipped}">
+            <div class="front" >
+                <div class="three-dots" @click="flipCard">
+                    <div class="dot-1"></div>
+                    <div class="dot-2"></div>
+                    <div class="dot-3"></div>
+                </div>
+                <div class="card-front" @click="goToProfessorDetail(professor.cod_professor)">
                     <div class="profile-picture-name">
                     <div class="profile-picture-div">                    
                         <img  :src="verificarUrl(professor.foto_professor)"  alt="" class="profile-picture">
@@ -21,7 +26,7 @@
                 </div>
                 <div class="rating-and-number">
                     <div class="rating"><p class="nota">{{professor.contribuicoes.media_nota_total.toFixed(2)}}</p><p class="de-cinco">/ 5</p></div>
-                    <div class="total-reviews">Total reviews ({{professor.qtd_avaliacoes}})</div>
+                    <div class="total-reviews">Total reviews ({{professor.qtdavaliacoes}})</div>
                 </div>
                 <div class="five-estrelas">
                     <img ref="estrelas" src="../../assets/icons/avaliacao/icone-estrela-azul.svg" alt="" class="estrela" v-for="n in 5" :key="n">
@@ -29,12 +34,12 @@
             </div>
                 
             </div>
-            <div class="back" @click="() => TogglePopup('buttonTrigger')">
+            <div class="back" >
                 <div class="review-breakdown">
                     Review breakdown
                 </div>
 
-                <div class="details-list">
+                <div class="details-list" @click="flipCard">
                     <div class="details">
                     <div class="number-stars">
                         Acesso
@@ -106,8 +111,10 @@
                 </div>
                     
                 </div>
-                
-            </div></div>
+                <button class="avali" @click="() => TogglePopup('buttonTrigger')">Avaliar</button>
+            </div>
+            
+        </div>
 
                 
         </div>
@@ -126,6 +133,11 @@ export default {
     name: "CardListagemProfessoresComponent",
     props: {
         professor: Object,
+    },
+    data(){
+        return{
+            isFlipped:false,
+        }
     },
     mounted(){
         nextTick(() => {
@@ -188,6 +200,10 @@ export default {
                     estrela.classList.add('empty-star');
                 }
             });
+        },
+
+        flipCard(){
+            this.isFlipped = !this.isFlipped;
         }
     }
 }
@@ -211,7 +227,7 @@ export default {
 .container {
     width: 100%;
     max-width: 350px;
-    height: 450px;
+    height: 500px;
     display: flex;
     justify-content: center
 }
@@ -237,9 +253,9 @@ export default {
 
 .back {
     transform: rotateY(180deg);
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
-    gap: 50px;
+    gap: 30px;
 
 
 }
@@ -249,6 +265,33 @@ export default {
     flex-direction: column;
     padding-left: 40px;
     gap: 30px;
+}
+
+.three-dots{
+    display: flex;
+    position: absolute;
+    top: 30px;
+    right: 30px;
+    z-index: 30;
+    gap: 2px;
+    cursor: pointer;
+
+}
+
+
+.card-professor.flipped{
+    cursor: pointer;
+    transform: rotateY(180deg);
+}
+
+
+.dot-1, .dot-2, .dot-3{
+    width: 4px;
+    height: 4px;
+    background-color: #535353;
+    border-radius: 100px;
+
+
 }
 
 .review-breakdown{
@@ -273,10 +316,7 @@ export default {
     align-items: center;
 }
 
-.container:hover > .card-professor {
-    cursor: pointer;
-    transform: rotateY(180deg);
-}
+
 
 .profile-picture-name {
     display: flex;
@@ -375,18 +415,40 @@ export default {
     font-weight: 500;
     color: rgb(83, 83, 83);
     width: 100%;
-    margin-left: 40px;
+    display: flex;
+    justify-content: center;
+}
+
+.details-list{
+
 }
 
 .details{
     display: flex;
     flex-direction: column;
     width: 100%;
-    justify-content: flex-start;
+    justify-content: center;
     margin-bottom: 10px;
-    align-items: flex-start;
+    align-items: center;
     gap: 10px;
-    margin-left: 40px;
+}
+
+.avali{
+
+    width: 80%;
+    padding: 10px 0px 10px 0;
+    border: none;
+    font-family: 'Inter', sans-serif;
+    background-color: #0a745b;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.avali:hover{
+    background-color: #07493a;
+    
 }
 
 .barra-texto{
@@ -409,7 +471,8 @@ export default {
     display: flex;
     flex-direction: column;
     width: 70%;
-    gap: 16px;
+    gap: 20px;
+    align-items: center;
 
 }
 
@@ -435,13 +498,13 @@ export default {
 @media screen and (max-width: 1000px) {
 
 .container{
-    height: 400px;
+    height: 450px;
 }
 .card-professor{
     padding-top: 0;
     padding-bottom: 0;
-    width: 70%;
-    height: 90%;
+    width: 90%;
+    height: 100%;
 }
 
 }

--- a/vue-app/src/components/Professores/PopupAvaliaProfessor.vue
+++ b/vue-app/src/components/Professores/PopupAvaliaProfessor.vue
@@ -120,15 +120,15 @@
     justify-content: center;
     position: relative;
     max-width: 400px;
-    width: 90vw;
+    width: 90%;
   }
 
   .select-box {
     appearance: none;
     padding: 1rem 0 1rem 1rem;
-    margin-right: 10px;
     font-size: 1.6rem;
-    width: 90vw;
+    width: 100%;
+    min-width: 253px;
     border-radius: 1rem;
     background-color: #f5f5f5;
     color: #333;
@@ -147,6 +147,7 @@
 
   select option.opcao {
     background-color: #ffffff; /* Fundo branco */
+
   }
 
 
@@ -154,11 +155,13 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     width: 100%;
     gap: 10px;
   }
   .popup{
     display: flex;
+    width: 100vw;
     align-items: center;
     justify-content: center;
     position: fixed;
@@ -168,11 +171,13 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 99;
+    z-index: 1000;
     background-color: rgba(0, 0, 0, 0.7);
     overflow-y: hidden;
 
   }
+
+
   .popup-header{
     width: 100%;
     display: flex;
@@ -216,11 +221,10 @@
     color: #034939b9;
     font-family: 'Inter', sans-serif;
     font-weight: 400;
-    border-radius: 10px;
-    padding: .8rem 16% .8rem 16%;
+    border-radius: 4px;
+    padding: 10px 16% 10px 16%;
     cursor: pointer;
     transition: all 0.4s;
-    margin-right: 10px;
   }
   .send-btn{
     background-color: #034939b9;
@@ -240,8 +244,7 @@
     margin-top: 3vh;
     margin-bottom: 1vh;
     display: flex;
-    gap: .5vw;
-    justify-content: center;
+    justify-content: space-around;
     width: 100%;
   }
 
@@ -249,6 +252,11 @@
   .rating-stars-div {
     display: flex;
     justify-content: center;
+    width: 90%;
+  }
+
+  .container{
+    width: 100%
   }
 
   .popup-inner{
@@ -259,21 +267,25 @@
     background: #fff;
     padding: 25px 25px 25px 25px;
     height: fit-content;
-    width: 95vw;
+    width: 78%;
     max-width: 500px;
     border-radius: 20px;
+    align-self: center;
   }
 
-  
+  .camp-txt{
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   .comentario{
-    width: 80vw;
-    max-width: 350px;
+    width: 90%;
     height: 6vh;
     font-size: 1.3rem;
-    border-radius: 10px;
-    background-color: #f5f5f5;
-    margin-right: 10px;
+    border-radius: 4px;
+    background-color: #f8f8f8ad;
     color: #333;
     padding: 1rem;
     font-family: 'Inter', sans-serif;
@@ -297,6 +309,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
+    align-items: center;
   }
   @media (max-width: 650px) {
       .select-box{

--- a/vue-app/src/components/Professores/RatingStarsProfessor.vue
+++ b/vue-app/src/components/Professores/RatingStarsProfessor.vue
@@ -74,8 +74,7 @@ export default {
     font-family: 'Open Sans', sans-serif;
     font-size: 1.6rem;
     font-weight: 500;
-    margin: 0;
-    padding-left: 1rem; /* Adiciona espaço entre as estrelas e o texto */
+    margin: 0; 
     flex: 1;
     text-align: left; /* Alinha o texto à esquerda */
   }
@@ -88,7 +87,7 @@ export default {
   }
   .notas{
     display: flex;
-    gap: 30px;
+    gap: 20px;
     align-items: center;
     justify-content: space-between;
   }
@@ -96,11 +95,11 @@ export default {
     display: flex;
     align-items: center;
     flex-direction: row-reverse;
-    gap: 10px;
+    gap: 15px;
   }
   .rating input{
     position: relative;
-    width: 2.3vw;
+    width: 3rem;
     height: 5vh;
     margin: 0;
     padding: 0;
@@ -116,7 +115,7 @@ export default {
     content: "\f005";
     position: absolute;
     font-family: fontAwesome;
-    font-size: 2.6rem;
+    font-size: 3rem;
     color: #b4b4b4a2;
     transition: 0.3s;
   }
@@ -134,7 +133,7 @@ export default {
   }
   @media (max-width: 500px) {
     .rating{
-      gap: 15px;
+      gap: 10px;
     }
   }
   @media (max-width: 350px) {

--- a/vue-app/src/service/professor/ManipulaDadosProfessorCardListagem.js
+++ b/vue-app/src/service/professor/ManipulaDadosProfessorCardListagem.js
@@ -68,7 +68,7 @@ export async function obterInformacoesProfessoresFiltrados(materia) {
                 cod_professor: professor.cod_professor,
                 foto_professor: professor.foto_professor,
                 materias_professor: professor.materias,
-                qtd_avaliacoes: professor.qtdavaliacoes,
+                qtdavaliacoes: professor.quantidade_avaliacoes,
                 contribuicoes: contribuicoes
             };
         });


### PR DESCRIPTION
O card de professores na página de listagem estáva virando com o hover do container dele. Entretando para o usuário fazer as navegações necessárias ficou muito difícil. Dessa forma foi implementado na parte da frente do card um ícone de 3 pontinhos para que o card vire quando o usuário clicar lá. Além disso, para desvirar o card o usuário deve clicar na parte de trás do card. Para  abrir o pop up de avaliação o usuário deve clicar no botão "Avaliar" na parte anterior do card também e assim é aberto o pop up de avaliação.